### PR TITLE
Added better error message for a nonstring marker

### DIFF
--- a/dahlia/utils.py
+++ b/dahlia/utils.py
@@ -46,6 +46,9 @@ def _find_ansi_codes(string: str) -> set[str]:
 
 
 def _with_marker(marker: str) -> list[re.Pattern[str]]:
+    if not isinstance(marker, str):
+        msg = "The marker has to be a string"
+        raise TypeError(msg)
     if len(marker) != 1:
         msg = "The marker has to be a single character"
         raise ValueError(msg)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -58,10 +58,12 @@ def test_invalid_marker(marker: str) -> None:
     with pytest.raises(ValueError, match="The marker has to be a single character"):
         Dahlia(marker=marker)
 
+
 @pytest.mark.parametrize("marker", [123, [1], {"key": "value"}])
 def test_nonstring_marker(marker: str) -> None:
     with pytest.raises(TypeError, match="The marker has to be a st"):
         Dahlia(marker=marker)
+
 
 @pytest.mark.parametrize(("auto_reset", "expected"), [(True, "\x1b[0m"), (False, "")])
 def test_auto_reset(auto_reset: bool, expected: str) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -58,6 +58,10 @@ def test_invalid_marker(marker: str) -> None:
     with pytest.raises(ValueError, match="The marker has to be a single character"):
         Dahlia(marker=marker)
 
+@pytest.mark.parametrize("marker", [123, [1], {"key": "value"}])
+def test_nonstring_marker(marker: str) -> None:
+    with pytest.raises(TypeError, match="The marker has to be a st"):
+        Dahlia(marker=marker)
 
 @pytest.mark.parametrize(("auto_reset", "expected"), [(True, "\x1b[0m"), (False, "")])
 def test_auto_reset(auto_reset: bool, expected: str) -> None:


### PR DESCRIPTION
Dahlia(marker=[1]) currently raises TypeError: can only concatenate list (not "str") to list.

changed to TypeError: the marker has to be a string

added test to test nonstring values