### PR TITLE
Fixed custom color processing

### DIFF
--- a/dahlia/lib.py
+++ b/dahlia/lib.py
@@ -124,10 +124,10 @@ class Dahlia:
         code_size, rem3 = divmod(len(code), 3)
         if not rem3:
             return formats[24].format(
-                *(
-                    (int(code[i : i + 2], 16) for i in (0, 2, 4))
+                ";".join(
+                    (str(int(code[i : i + 2], 16)) for i in (0, 2, 4))
                     if code_size == 2
-                    else (int(i, 16) * 0x11 for i in code)
+                    else (str(int(i, 16) * 0x11) for i in code)
                 )
             )
         if code in FORMATTERS:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -30,6 +30,8 @@ from dahlia.lib import Dahlia, Depth
         (Depth.HIGH, "&9aspergillaceae", "\x1b[38;2;85;85;255maspergillaceae"),
         (Depth.LOW, "&~edemigod", "\x1b[103mdemigod"),
         (Depth.TTY, "&9miller", "\x1b[34mmiller"),
+        (Depth.HIGH, "&#ffaff3;gleaming", "\x1b[38;2;255;175;243mgleaming"),
+        (Depth.HIGH, "&#fbf;gweaming", "\x1b[38;2;255;187;255mgweaming"),
     ],
 )
 def test_conversion(depth: Depth, string: str, expected: str) -> None:


### PR DESCRIPTION
Until now it would only include the red part, so `#ffaff3` was treated like `#ff0000`